### PR TITLE
Updated Sampling Result names

### DIFF
--- a/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
+++ b/examples/sdk-usage/src/main/java/io/opentelemetry/sdk/example/ConfigureTraceExample.java
@@ -119,7 +119,7 @@ class ConfigureTraceExample {
           List<Link> parentLinks) {
         // We sample only if the Span name contains "SAMPLE"
         return Samplers.emptySamplingResult(
-            name.contains("SAMPLE") ? Decision.RECORD_AND_SAMPLED : Decision.NOT_RECORD);
+            name.contains("SAMPLE") ? Decision.RECORD_AND_SAMPLE : Decision.DROP);
       }
 
       @Override

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Sampler.java
@@ -69,9 +69,9 @@ public interface Sampler {
 
   /** A decision on whether a span should be recorded, recorded and sampled or not recorded. */
   enum Decision {
-    NOT_RECORD,
-    RECORD,
-    RECORD_AND_SAMPLED,
+    DROP,
+    RECORD_ONLY,
+    RECORD_AND_SAMPLE,
   }
 
   /**
@@ -94,8 +94,8 @@ public interface Sampler {
      * Return tags which will be attached to the span.
      *
      * @return attributes added to span. These attributes should be added to the span only when
-     *     {@linkplain #getDecision() the sampling decision} is {@link Decision#RECORD} or {@link
-     *     Decision#RECORD_AND_SAMPLED}.
+     *     {@linkplain #getDecision() the sampling decision} is {@link Decision#RECORD_ONLY} or {@link
+     *     Decision#RECORD_AND_SAMPLE}.
      * @since 0.1.0
      */
     Attributes getAttributes();

--- a/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
+++ b/sdk/tracing/src/main/java/io/opentelemetry/sdk/trace/Samplers.java
@@ -56,21 +56,21 @@ public final class Samplers {
       DoubleAttributeSetter.create("sampling.probability");
 
   private static final SamplingResult EMPTY_RECORDED_AND_SAMPLED_SAMPLING_RESULT =
-      SamplingResultImpl.createWithoutAttributes(Decision.RECORD_AND_SAMPLED);
+      SamplingResultImpl.createWithoutAttributes(Decision.RECORD_AND_SAMPLE);
   private static final SamplingResult EMPTY_NOT_SAMPLED_OR_RECORDED_SAMPLING_RESULT =
-      SamplingResultImpl.createWithoutAttributes(Decision.NOT_RECORD);
+      SamplingResultImpl.createWithoutAttributes(Decision.DROP);
   private static final SamplingResult EMPTY_RECORDED_SAMPLING_RESULT =
-      SamplingResultImpl.createWithoutAttributes(Decision.RECORD);
+      SamplingResultImpl.createWithoutAttributes(Decision.RECORD_ONLY);
 
   // No instance of this class.
   private Samplers() {}
 
   static boolean isRecording(Decision decision) {
-    return Decision.RECORD.equals(decision) || Decision.RECORD_AND_SAMPLED.equals(decision);
+    return Decision.RECORD_ONLY.equals(decision) || Decision.RECORD_AND_SAMPLE.equals(decision);
   }
 
   static boolean isSampled(Decision decision) {
-    return Decision.RECORD_AND_SAMPLED.equals(decision);
+    return Decision.RECORD_AND_SAMPLE.equals(decision);
   }
 
   /**
@@ -108,11 +108,11 @@ public final class Samplers {
    */
   public static SamplingResult emptySamplingResult(Decision decision) {
     switch (decision) {
-      case RECORD_AND_SAMPLED:
+      case RECORD_AND_SAMPLE:
         return EMPTY_RECORDED_AND_SAMPLED_SAMPLING_RESULT;
-      case RECORD:
+      case RECORD_ONLY:
         return EMPTY_RECORDED_SAMPLING_RESULT;
-      case NOT_RECORD:
+      case DROP:
         return EMPTY_NOT_SAMPLED_OR_RECORDED_SAMPLING_RESULT;
     }
     throw new AssertionError("unrecognised samplingResult");
@@ -453,8 +453,8 @@ public final class Samplers {
       return new AutoValue_Samplers_Probability(
           probability,
           idUpperBound,
-          SamplingResultImpl.createWithProbability(Decision.RECORD_AND_SAMPLED, probability),
-          SamplingResultImpl.createWithProbability(Decision.NOT_RECORD, probability));
+          SamplingResultImpl.createWithProbability(Decision.RECORD_AND_SAMPLE, probability),
+          SamplingResultImpl.createWithProbability(Decision.DROP, probability));
     }
 
     abstract double getProbability();

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SamplersTest.java
@@ -58,30 +58,30 @@ class SamplersTest {
 
   @Test
   void emptySamplingDecision() {
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE));
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.DROP))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.DROP));
 
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED).getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE).getDecision())
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(
-            Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED)
+            Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE)
                 .getAttributes()
                 .isEmpty())
         .isTrue();
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD).getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
-    assertThat(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD).getAttributes().isEmpty())
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.DROP).getDecision())
+        .isEqualTo(Decision.DROP);
+    assertThat(Samplers.emptySamplingResult(Sampler.Decision.DROP).getAttributes().isEmpty())
         .isTrue();
   }
 
   @Test
   void samplingDecisionEmpty() {
-    assertThat(Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLED, Attributes.empty()))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLED));
-    assertThat(Samplers.samplingResult(Sampler.Decision.NOT_RECORD, Attributes.empty()))
-        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.NOT_RECORD));
+    assertThat(Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLE, Attributes.empty()))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.RECORD_AND_SAMPLE));
+    assertThat(Samplers.samplingResult(Sampler.Decision.DROP, Attributes.empty()))
+        .isSameAs(Samplers.emptySamplingResult(Sampler.Decision.DROP));
   }
 
   @Test
@@ -91,13 +91,13 @@ class SamplersTest {
             "foo", AttributeValue.longAttributeValue(42),
             "bar", AttributeValue.stringAttributeValue("baz"));
     final SamplingResult sampledSamplingResult =
-        Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLED, attrs);
-    assertThat(sampledSamplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
+        Samplers.samplingResult(Sampler.Decision.RECORD_AND_SAMPLE, attrs);
+    assertThat(sampledSamplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(sampledSamplingResult.getAttributes()).isEqualTo(attrs);
 
     final SamplingResult notSampledSamplingResult =
-        Samplers.samplingResult(Sampler.Decision.NOT_RECORD, attrs);
-    assertThat(notSampledSamplingResult.getDecision()).isEqualTo(Decision.NOT_RECORD);
+        Samplers.samplingResult(Sampler.Decision.DROP, attrs);
+    assertThat(notSampledSamplingResult.getDecision()).isEqualTo(Decision.DROP);
     assertThat(notSampledSamplingResult.getAttributes()).isEqualTo(attrs);
   }
 
@@ -114,7 +114,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
@@ -127,7 +127,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Null parent.
     assertThat(
@@ -140,7 +140,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -161,7 +161,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     // Not sampled parent.
     assertThat(
@@ -174,7 +174,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     // Null parent.
     assertThat(
@@ -187,7 +187,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -208,7 +208,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
@@ -221,7 +221,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -237,7 +237,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     // Not sampled parent.
     assertThat(
@@ -250,7 +250,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -267,7 +267,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -281,7 +281,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -295,7 +295,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -309,7 +309,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -327,7 +327,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -341,7 +341,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -355,7 +355,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -369,7 +369,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -386,7 +386,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -400,7 +400,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -414,7 +414,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -428,7 +428,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
   }
 
   @Test
@@ -445,7 +445,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -459,7 +459,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -473,7 +473,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOn())
@@ -487,7 +487,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -502,7 +502,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBased(Samplers.alwaysOff())
@@ -514,7 +514,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBasedBuilder(Samplers.alwaysOff())
@@ -531,7 +531,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
 
     assertThat(
             Samplers.parentBased(Samplers.alwaysOn())
@@ -543,7 +543,7 @@ class SamplersTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -718,7 +718,7 @@ class SamplersTest {
             SPAN_KIND,
             Attributes.empty(),
             Collections.emptyList());
-    assertThat(samplingResult1.getDecision()).isEqualTo(Decision.NOT_RECORD);
+    assertThat(samplingResult1.getDecision()).isEqualTo(Decision.DROP);
     assertThat(samplingResult1.getAttributes())
         .isEqualTo(
             Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
@@ -752,7 +752,7 @@ class SamplersTest {
             SPAN_KIND,
             Attributes.empty(),
             Collections.emptyList());
-    assertThat(samplingResult2.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
+    assertThat(samplingResult2.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(samplingResult1.getAttributes())
         .isEqualTo(
             Attributes.of(Samplers.SAMPLING_PROBABILITY.key(), doubleAttributeValue(0.0001)));
@@ -760,15 +760,15 @@ class SamplersTest {
 
   @Test
   void isSampled() {
-    assertThat(Samplers.isSampled(Decision.NOT_RECORD)).isFalse();
-    assertThat(Samplers.isSampled(Decision.RECORD)).isFalse();
-    assertThat(Samplers.isSampled(Decision.RECORD_AND_SAMPLED)).isTrue();
+    assertThat(Samplers.isSampled(Decision.DROP)).isFalse();
+    assertThat(Samplers.isSampled(Decision.RECORD_ONLY)).isFalse();
+    assertThat(Samplers.isSampled(Decision.RECORD_AND_SAMPLE)).isTrue();
   }
 
   @Test
   void isRecording() {
-    assertThat(Samplers.isRecording(Decision.NOT_RECORD)).isFalse();
-    assertThat(Samplers.isRecording(Decision.RECORD)).isTrue();
-    assertThat(Samplers.isRecording(Decision.RECORD_AND_SAMPLED)).isTrue();
+    assertThat(Samplers.isRecording(Decision.DROP)).isFalse();
+    assertThat(Samplers.isRecording(Decision.RECORD_ONLY)).isTrue();
+    assertThat(Samplers.isRecording(Decision.RECORD_AND_SAMPLE)).isTrue();
   }
 }

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/SpanBuilderSdkTest.java
@@ -561,7 +561,7 @@ class SpanBuilderSdkTest {
                         return new SamplingResult() {
                           @Override
                           public Decision getDecision() {
-                            return Decision.RECORD_AND_SAMPLED;
+                            return Decision.RECORD_AND_SAMPLE;
                           }
 
                           @Override

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessorTest.java
@@ -71,7 +71,7 @@ class BatchSpanProcessorTest {
     tracerSdkFactory.shutdown();
   }
 
-  // TODO(bdrutu): Fix this when Sampler return RECORD option.
+  // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
   /*
   private ReadableSpan createNotSampledRecordingEventsEndedSpan(String spanName) {
     io.opentelemetry.trace.Span span =
@@ -400,7 +400,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void exportNotSampledSpans_recordingEvents() {
-    // TODO(bdrutu): Fix this when Sampler return RECORD option.
+    // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracerSdkFactory.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)
@@ -416,7 +416,7 @@ class BatchSpanProcessorTest {
 
   @Test
   void exportNotSampledSpans_reportOnlySampled() {
-    // TODO(bdrutu): Fix this when Sampler return RECORD option.
+    // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracerSdkFactory.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)

--- a/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
+++ b/sdk/tracing/src/test/java/io/opentelemetry/sdk/trace/export/SimpleSpanProcessorTest.java
@@ -172,7 +172,7 @@ class SimpleSpanProcessorTest {
 
   @Test
   void tracerSdk_NotSampled_RecordingEventsSpan() {
-    // TODO(bdrutu): Fix this when Sampler return RECORD option.
+    // TODO(bdrutu): Fix this when Sampler return RECORD_ONLY option.
     /*
     tracer.addSpanProcessor(
         BatchSpanProcessor.newBuilder(waitingSpanExporter)

--- a/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/main/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSampler.java
@@ -55,8 +55,8 @@ class RateLimitingSampler implements Sampler {
         Attributes.of(
             SAMPLER_TYPE, AttributeValue.stringAttributeValue(TYPE),
             SAMPLER_PARAM, AttributeValue.doubleAttributeValue(maxTracesPerSecond));
-    this.onSamplingResult = Samplers.samplingResult(Decision.RECORD_AND_SAMPLED, attributes);
-    this.offSamplingResult = Samplers.samplingResult(Decision.NOT_RECORD, attributes);
+    this.onSamplingResult = Samplers.samplingResult(Decision.RECORD_AND_SAMPLE, attributes);
+    this.offSamplingResult = Samplers.samplingResult(Decision.DROP, attributes);
   }
 
   @Override

--- a/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
+++ b/sdk_extensions/jaeger_remote_sampler/src/test/java/io/opentelemetry/sdk/extensions/trace/jaeger/sampler/RateLimitingSamplerTest.java
@@ -56,7 +56,7 @@ class RateLimitingSamplerTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(
             sampler
                 .shouldSample(
@@ -67,7 +67,7 @@ class RateLimitingSamplerTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.RECORD_AND_SAMPLED);
+        .isEqualTo(Decision.RECORD_AND_SAMPLE);
   }
 
   @Test
@@ -81,7 +81,7 @@ class RateLimitingSamplerTest {
             SPAN_KIND,
             Attributes.empty(),
             Collections.emptyList());
-    assertThat(samplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLED);
+    assertThat(samplingResult.getDecision()).isEqualTo(Decision.RECORD_AND_SAMPLE);
     assertThat(
             sampler
                 .shouldSample(
@@ -92,7 +92,7 @@ class RateLimitingSamplerTest {
                     Attributes.empty(),
                     Collections.emptyList())
                 .getDecision())
-        .isEqualTo(Decision.NOT_RECORD);
+        .isEqualTo(Decision.DROP);
     assertEquals(2, samplingResult.getAttributes().size());
     assertEquals(
         AttributeValue.doubleAttributeValue(1),


### PR DESCRIPTION
This PR updates the names of Sampling result for consistency, closing [#1648](https://github.com/open-telemetry/opentelemetry-java/issues/1648)

The changes have been made following these specifications:  
[open-telemetry/opentelemetry-specification#938](https://github.com/open-telemetry/opentelemetry-specification/pull/938)
[open-telemetry/opentelemetry-specification#956 ](https://github.com/open-telemetry/opentelemetry-specification/pull/956)


Changed from:

- `NOT_RECORD`

- `RECORD`

- `RECORD_AND_SAMPLED`

Changed to: 

- `DROP`

- `RECORD_ONLY`

- `RECORD_AND_SAMPLE`