### PR TITLE
TLS enabling controlled by insecure flag

### DIFF
--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcMetricExporter.java
@@ -314,7 +314,7 @@ public final class OtlpGrpcMetricExporter implements MetricExporter {
         useTlsValue = getBooleanProperty(CommonProperties.KEY_USE_TLS, configMap);
       }
       if (useTlsValue != null) {
-        this.setUseTls(useTlsValue);
+        this.setUseTls(!useTlsValue);
       }
 
       String metadataValue = getStringProperty(KEY_HEADERS, configMap);

--- a/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
+++ b/exporters/otlp/src/main/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporter.java
@@ -323,7 +323,7 @@ public final class OtlpGrpcSpanExporter implements SpanExporter {
         useTlsValue = getBooleanProperty(CommonProperties.KEY_USE_TLS, configMap);
       }
       if (useTlsValue != null) {
-        this.setUseTls(useTlsValue);
+        this.setUseTls(!useTlsValue);
       }
 
       String metadataValue = getStringProperty(KEY_HEADERS, configMap);

--- a/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
+++ b/exporters/otlp/src/test/java/io/opentelemetry/exporters/otlp/OtlpGrpcSpanExporterTest.java
@@ -71,7 +71,7 @@ class OtlpGrpcSpanExporterTest {
     spy.fromConfigMap(options, ConfigBuilderTest.getNaming());
     Mockito.verify(spy).setDeadlineMs(12);
     Mockito.verify(spy).setEndpoint("http://localhost:6553");
-    Mockito.verify(spy).setUseTls(true);
+    Mockito.verify(spy).setUseTls(false);
     Mockito.verify(spy).addHeader("key", "value");
     Mockito.verify(spy).addHeader("key2", "value2=");
     Mockito.verify(spy).addHeader("key3", "val=ue3");


### PR DESCRIPTION
This PR changes the way TLS enable is controlled by the insecure flag, choosing [#1673](https://github.com/open-telemetry/opentelemetry-java/issues/1673).

The `insecure = false` means it requires setting a certificate. 

In the previous code, the enabling and disabling of TLS was flipped: 
TLS is disabled when insecure is false and enabled when insecure is true.

Changes have been made so that TLS is enabled when insecure is false and disabled when insecure is true.

